### PR TITLE
fix: bad hint in step 860 and other typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@ Whenever a new version is created, add the new branch name and the changes here
 
 - Move setup commands from `coderoad.yaml` to `setup.sh`
 - Add creation of `.bash_history` in setup commands so CodeRoad watchers recognize it when the first command is entered
+
+## [v1.0.2]
+
+- Step 860 changes command operator from `>` to `>>`
+- Fix some typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,3 @@ Whenever a new version is created, add the new branch name and the changes here
 
 - Move setup commands from `coderoad.yaml` to `setup.sh`
 - Add creation of `.bash_history` in setup commands so CodeRoad watchers recognize it when the first command is entered
-
-## [v1.0.2]
-
-- Step 860 changes command operator from `>` to `>>`
-- Fix some typos

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1133,7 +1133,7 @@ Awesome. Enter the last command and append the line numbers to the `kitty_info.t
 - You previously used `grep -n 'meow[a-z]*' kitty_ipsum_1.txt | sed -E 's/([0-9]+).*/\1/' >> kitty_info.txt`
 - Enter `grep -n 'cat[a-z]*' kitty_ipsum_1.txt | sed -E 's/([0-9]+).*/\1/' >> kitty_info.txt` in the terminal
 
-## 860. echo -e \n\n~~ kitty_ispsum_2.txt info ~~ > kitty_info
+## 860. echo -e \n\n~~ kitty_ispsum_2.txt info ~~ >> kitty_info
 
 ### 860.1
 
@@ -1144,7 +1144,7 @@ Hopefully your info file is looking good. Next, you want to do the same thing fo
 - You want the `echo` command with the `-e` flag and the new line character (`\n`) twice
 - Here's an example: `echo -e "\n\n<text>" >> <filename>`
 - You previously entered `echo -e "\nLines that they appear on:" >> kitty_info.txt`
-- Enter `echo -e "\n\n~~ kitty_ispsum_2.txt info ~~" > kitty_info.txt` in the terminal
+- Enter `echo -e "\n\n~~ kitty_ispsum_2.txt info ~~" >> kitty_info.txt` in the terminal
 
 ## 870. echo -e \nNumber of lines: >> kitty_info
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1571,7 +1571,7 @@ As expected, it replaced instances of `cat` with `dog`. Enter the same command, 
 
 ### 1140.1
 
-It didn't find any so it must be replacing them all. You added two patterns as part of the `sed` in your script. Add a third that replaces all `moew` words with `woof`.
+It didn't find any so it must be replacing them all. You added two patterns as part of the `sed` in your script. Add a third that replaces all `meow` words with `woof`.
 
 #### HINTS
 
@@ -1616,7 +1616,7 @@ That didn't work. Enter the same command, but add the flag to use extended regul
 
 ### 1170.1
 
-If you look closely, you can see that the `meow` part of `meowzer` on that one line didn't get replaced with `woof`. `grep` only matched the first instand of `meow` it found on that line. Add the "global" regex flag to all three patterns of the `sed` command in your script so it will replace all instances of any of the words.
+If you look closely, you can see that the `meow` part of `meowzer` on that one line didn't get replaced with `woof`. `grep` only matched the first instance of `meow` it found on that line. Add the "global" regex flag to all three patterns of the `sed` command in your script so it will replace all instances of any of the words.
 
 #### HINTS
 

--- a/tutorial.json
+++ b/tutorial.json
@@ -3233,7 +3233,7 @@
               "8b45a7bdb29f7027cdfbd1a0e9780ee2b2a3a6a5"
             ]
           },
-          "content": "It didn't find any so it must be replacing them all. You added two patterns as part of the `sed` in your script. Add a third that replaces all `moew` words with `woof`.",
+          "content": "It didn't find any so it must be replacing them all. You added two patterns as part of the `sed` in your script. Add a third that replaces all `meow` words with `woof`.",
           "hints": [
             "You can add another pattern to replace like before. Add a semi-colon and another pattern in the quotes of the `sed`",
             "Here's an example: `sed 's///; s///; s///'`",
@@ -3312,7 +3312,7 @@
               "be999efa13e9305f3b399a7698f10693781cbf86"
             ]
           },
-          "content": "If you look closely, you can see that the `meow` part of `meowzer` on that one line didn't get replaced with `woof`. `grep` only matched the first instand of `meow` it found on that line. Add the \"global\" regex flag to all three patterns of the `sed` command in your script so it will replace all instances of any of the words.",
+          "content": "If you look closely, you can see that the `meow` part of `meowzer` on that one line didn't get replaced with `woof`. `grep` only matched the first instance of `meow` it found on that line. Add the \"global\" regex flag to all three patterns of the `sed` command in your script so it will replace all instances of any of the words.",
           "hints": [
             "Here's an example of one pattern: `s/<pattern>/<replacement>/<regex_flags>`",
             "It's the `g` flag",

--- a/tutorial.json
+++ b/tutorial.json
@@ -3061,7 +3061,7 @@
           "hints": [
             "Here's an example: `cat $1 | sed 's/<pattern>/<replacement>/'`",
             "The `sed` argument should be `s/catnip/dogchow/`",
-            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed 's/catnip/dogchow'\r\n```"
+            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow'\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -3238,7 +3238,7 @@
             "You can add another pattern to replace like before. Add a semi-colon and another pattern in the quotes of the `sed`",
             "Here's an example: `sed 's///; s///; s///'`",
             "The third pattern should be `s/meow/woof/`",
-            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/; s/cat/dog/; s/meow/woof/'\r\n```"
+            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/; s/cat/dog/; s/meow/woof/'\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -3162,7 +3162,7 @@
           "content": "It didn't output anything, so it must be replacing all the instances of `catnip`. You can replace many patterns using `sed` like this: `sed 's/<pattern_1>/<replacement_1>/; s/<pattern_2>/<replacement_2>/'`. Note that you need the semi-colon between the two replacement patterns and they both need to be wrapped in the quotes. In your script, add another pattern to the `sed` command that replaces `cat` with `dog`.",
           "hints": [
             "The code looks like this: `s/cat/dog/`",
-            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\r\n```"
+            "The `translate.sh` file should look like this:\n```sh\r\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -2392,7 +2392,7 @@
     },
     {
       "id": "860",
-      "title": "echo -e \\n\\n~~ kitty_ispsum_2.txt info ~~ > kitty_info",
+      "title": "echo -e \\n\\n~~ kitty_ispsum_2.txt info ~~ >> kitty_info",
       "summary": "",
       "content": "",
       "steps": [
@@ -2411,7 +2411,7 @@
             "You want the `echo` command with the `-e` flag and the new line character (`\\n`) twice",
             "Here's an example: `echo -e \"\\n\\n<text>\" >> <filename>`",
             "You previously entered `echo -e \"\\nLines that they appear on:\" >> kitty_info.txt`",
-            "Enter `echo -e \"\\n\\n~~ kitty_ispsum_2.txt info ~~\" > kitty_info.txt` in the terminal"
+            "Enter `echo -e \"\\n\\n~~ kitty_ispsum_2.txt info ~~\" >> kitty_info.txt` in the terminal"
           ]
         }
       ]
@@ -3061,7 +3061,7 @@
           "hints": [
             "Here's an example: `cat $1 | sed 's/<pattern>/<replacement>/'`",
             "The `sed` argument should be `s/catnip/dogchow/`",
-            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow'\n```"
+            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed 's/catnip/dogchow'\r\n```"
           ]
         }
       ]
@@ -3162,7 +3162,7 @@
           "content": "It didn't output anything, so it must be replacing all the instances of `catnip`. You can replace many patterns using `sed` like this: `sed 's/<pattern_1>/<replacement_1>/; s/<pattern_2>/<replacement_2>/'`. Note that you need the semi-colon between the two replacement patterns and they both need to be wrapped in the quotes. In your script, add another pattern to the `sed` command that replaces `cat` with `dog`.",
           "hints": [
             "The code looks like this: `s/cat/dog/`",
-            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\n```"
+            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\r\n```"
           ]
         }
       ]
@@ -3238,7 +3238,7 @@
             "You can add another pattern to replace like before. Add a semi-colon and another pattern in the quotes of the `sed`",
             "Here's an example: `sed 's///; s///; s///'`",
             "The third pattern should be `s/meow/woof/`",
-            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/; s/cat/dog/; s/meow/woof/'\n```"
+            "The `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/; s/cat/dog/; s/meow/woof/'\r\n```"
           ]
         }
       ]
@@ -3316,7 +3316,7 @@
           "hints": [
             "Here's an example of one pattern: `s/<pattern>/<replacement>/<regex_flags>`",
             "It's the `g` flag",
-            "Your `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow/woof/g'\n```"
+            "Your `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow/woof/g'\r\n```"
           ]
         }
       ]
@@ -3365,7 +3365,7 @@
           "hints": [
             "The last `sed` pattern in you scrip should be `s/meow|meowzer/woof/`",
             "And you should add the `-E` flag to the `sed` command",
-            "Your `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow|meowzer/woof/g'\n```"
+            "Your `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow|meowzer/woof/g'\r\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -3316,7 +3316,7 @@
           "hints": [
             "Here's an example of one pattern: `s/<pattern>/<replacement>/<regex_flags>`",
             "It's the `g` flag",
-            "Your `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow/woof/g'\r\n```"
+            "Your `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow/woof/g'\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -3365,7 +3365,7 @@
           "hints": [
             "The last `sed` pattern in you scrip should be `s/meow|meowzer/woof/`",
             "And you should add the `-E` flag to the `sed` command",
-            "Your `translate.sh` file should look like this:\r\n```sh\r\n#!/bin/bash\r\n\r\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow|meowzer/woof/g'\r\n```"
+            "Your `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed -E 's/catnip/dogchow/g; s/cat/dog/g; s/meow|meowzer/woof/g'\n```"
           ]
         }
       ]

--- a/tutorial.json
+++ b/tutorial.json
@@ -3162,7 +3162,7 @@
           "content": "It didn't output anything, so it must be replacing all the instances of `catnip`. You can replace many patterns using `sed` like this: `sed 's/<pattern_1>/<replacement_1>/; s/<pattern_2>/<replacement_2>/'`. Note that you need the semi-colon between the two replacement patterns and they both need to be wrapped in the quotes. In your script, add another pattern to the `sed` command that replaces `cat` with `dog`.",
           "hints": [
             "The code looks like this: `s/cat/dog/`",
-            "The `translate.sh` file should look like this:\n```sh\r\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\n```"
+            "The `translate.sh` file should look like this:\n```sh\n#!/bin/bash\n\ncat $1 | sed 's/catnip/dogchow; s/cat/dog/'\n```"
           ]
         }
       ]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Hi, I tried to follow the instructions on [](https://contribute.freecodecamp.org/#/how-to-work-on-tutorials-that-use-coderoad) but I couldn't get the `git branch vX.X.X upstream/vX.X.X`  command to work & I'm not sure what it does. 
The change is pretty simple and should be working, but I did not find an easy way to go back to step 860 to test the change.

Feel free to decline the PR and apply the changes with the proper commits, branch names, etc.
As it is now, neither
`echo -e \n\n~~ kitty_ispsum_2.txt info ~~ >> kitty_info` nor
`echo -e \n\n~~ kitty_ispsum_2.txt info ~~ > kitty_info` make the lesson advance to the next step.
